### PR TITLE
fix: harden Sophos Endpoint Protection requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2021-2025 Splunk Inc.
+   Copyright (c) 2021-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Sophos Endpoint Protection
-Copyright (c) 2021-2025 Splunk Inc.
+Copyright (c) 2021-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Sophos Endpoint Protection
 
-Publisher: Splunk Community \
-Connector Version: 1.2.1 \
-Product Vendor: Sophos \
-Product Name: Sophos Endpoint Protection \
-Minimum Product Version: 5.5.0
+Publisher: Splunk Community <br>
+Connector Version: 1.2.1 <br>
+Product Vendor: Sophos <br>
+Product Name: Sophos Endpoint Protection <br>
+Minimum Product Version: 6.3.0
 
 This app supports various investigative and containment actions on Sophos Endpoint Protection
 
@@ -19,29 +19,29 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[list endpoints](#action-list-endpoints) - List all the endpoints/sensors configured on the device \
-[check updates](#action-check-updates) - Send a request to the endpoint to check for Sophos management agent software updates \
-[tamper protection switch](#action-tamper-protection-switch) - Turn Tamper Protection on or off on the endpoint \
-[get tamperprotection settings](#action-get-tamperprotection-settings) - Get the Tamper Protection settings for the specified endpoint \
-[perform scan](#action-perform-scan) - Send a request to the specified endpoint to perform or configure a scan \
-[delete endpoint](#action-delete-endpoint) - Delete the specified endpoint \
-[get individual endpoint](#action-get-individual-endpoint) - Get the endpoint based on ID \
-[list items](#action-list-items) - Get all allowed or blocked items \
-[delete item](#action-delete-item) - Delete the specified blocked or allowed item \
-[block item](#action-block-item) - Add item to blocked list \
-[allow item](#action-allow-item) - Add item to allowed list \
-[list sites](#action-list-sites) - Get all local sites \
-[delete site](#action-delete-site) - Delete the specified local site \
-[add site](#action-add-site) - Add a new local site \
-[get isolation settings](#action-get-isolation-settings) - Get isolation settings for an endpoint \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[list endpoints](#action-list-endpoints) - List all the endpoints/sensors configured on the device <br>
+[check updates](#action-check-updates) - Send a request to the endpoint to check for Sophos management agent software updates <br>
+[tamper protection switch](#action-tamper-protection-switch) - Turn Tamper Protection on or off on the endpoint <br>
+[get tamperprotection settings](#action-get-tamperprotection-settings) - Get the Tamper Protection settings for the specified endpoint <br>
+[perform scan](#action-perform-scan) - Send a request to the specified endpoint to perform or configure a scan <br>
+[delete endpoint](#action-delete-endpoint) - Delete the specified endpoint <br>
+[get individual endpoint](#action-get-individual-endpoint) - Get the endpoint based on ID <br>
+[list items](#action-list-items) - Get all allowed or blocked items <br>
+[delete item](#action-delete-item) - Delete the specified blocked or allowed item <br>
+[block item](#action-block-item) - Add item to blocked list <br>
+[allow item](#action-allow-item) - Add item to allowed list <br>
+[list sites](#action-list-sites) - Get all local sites <br>
+[delete site](#action-delete-site) - Delete the specified local site <br>
+[add site](#action-add-site) - Add a new local site <br>
+[get isolation settings](#action-get-isolation-settings) - Get isolation settings for an endpoint <br>
 [isolation switch](#action-isolation-switch) - Turn on or off endpoint isolation for multiple endpoints
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -56,7 +56,7 @@ No Output
 
 List all the endpoints/sensors configured on the device
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -136,7 +136,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Send a request to the endpoint to check for Sophos management agent software updates
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -163,7 +163,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Turn Tamper Protection on or off on the endpoint
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 Turn Tamper Protection on or off on the endpoint or generate a new Tamper Protection password. Note that Tamper Protection can be enabled for an endpoint only if it has also been enabled globally.
@@ -197,7 +197,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get the Tamper Protection settings for the specified endpoint
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -226,7 +226,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Send a request to the specified endpoint to perform or configure a scan
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -252,7 +252,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Delete the specified endpoint
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -277,7 +277,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get the endpoint based on ID
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -339,7 +339,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get all allowed or blocked items
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -372,7 +372,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Delete the specified blocked or allowed item
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -399,7 +399,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add item to blocked list
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Block an item from exoneration by SHA256 checksum.
@@ -438,7 +438,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add item to allowed list
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Exempt an item from conviction by path, SHA256 checksum or certificate signer.
@@ -484,7 +484,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get all local sites
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -515,8 +515,8 @@ summary.total_objects_successful | numeric | | |
 
 Delete the specified local site
 
-Type: **correct** \
-Read only: **True**
+Type: **correct** <br>
+Read only: **False**
 
 #### Action Parameters
 
@@ -540,7 +540,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add a new local site
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -575,7 +575,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get isolation settings for an endpoint
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -606,7 +606,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Turn on or off endpoint isolation for multiple endpoints
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -642,7 +642,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/readme.html
+++ b/readme.html
@@ -1,5 +1,5 @@
 <!-- File: readme.html
-  Copyright (c) 2021-2025 Splunk Inc.
+  Copyright (c) 2021-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* chore: refresh connector development tooling (Written by Codex)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* chore: refresh connector development tooling (Written by Codex)
+* PAPP-38049: Validate API hosts, protect authentication state, and safely encode resource identifiers (Written by Codex)

--- a/sophosendpointprotection.json
+++ b/sophosendpointprotection.json
@@ -21,12 +21,12 @@
             "name": "John Wang"
         }
     ],
-    "license": "Copyright (c) 2021-2025 Splunk Inc.",
+    "license": "Copyright (c) 2021-2026 Splunk Inc.",
     "app_version": "1.2.1",
     "utctime_updated": "2025-04-28T19:26:30.575141Z",
     "package_name": "phantom_sophosendpointprotection",
     "main_module": "sophosendpointprotection_connector.py",
-    "min_phantom_version": "5.5.0",
+    "min_phantom_version": "6.3.0",
     "fips_compliant": false,
     "app_wizard_version": "1.0.0",
     "configuration": {
@@ -2206,6 +2206,14 @@
         }
     ],
     "pip39_dependencies": {
+        "wheel": [
+            {
+                "module": "chardet",
+                "input_file": "wheels/shared/chardet-3.0.4-py2.py3-none-any.whl"
+            }
+        ]
+    },
+    "pip313_dependencies": {
         "wheel": [
             {
                 "module": "chardet",

--- a/sophosendpointprotection.json
+++ b/sophosendpointprotection.json
@@ -1794,7 +1794,7 @@
             "identifier": "delete_site",
             "description": "Delete the specified local site",
             "type": "correct",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "site_id": {
                     "description": "The local site ID",

--- a/sophosendpointprotection_connector.py
+++ b/sophosendpointprotection_connector.py
@@ -1,6 +1,6 @@
 # File: sophosendpointprotection_connector.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@
 
 import json
 import re
+from urllib.parse import quote, urlparse
 
 # Phantom App imports
+import encryption_helper
 import phantom.app as phantom
 import requests
 from bs4 import BeautifulSoup
@@ -51,23 +53,102 @@ class SophosEndpointProtectionConnector(BaseConnector):
         self._client_id = config[SOPHOS_CLIENT_ID].encode("utf-8")
         self._client_secret = config[SOPHOS_CLIENT_SECRET].encode("utf-8")
         self._state = self.load_state()
-        self._JWT_token = self._state.get(SOPHOS_JWT_JSON, {}).get(SOPHOS_JWT_TOKEN)
+        self._load_jwt_from_state()
         pt_json = self._state.get(SOPHOS_PT_JSON, None)
-        # self.save_progress("Printing the pt_json: ".format(str(json.dumps(pt_json))))
         if pt_json is not None:
-            self._id_type = pt_json["idType"]
-            if pt_json["idType"] == "tenant":
-                self._base_url = pt_json.get(SOPHOS_PT_API_HOSTS, {}).get(SOPHOS_PT_DATA_REGION_URL, None)
-            elif pt_json["idType"] == "organization" or pt_json["idType"] == "partner":
-                self._base_url = pt_json.get(SOPHOS_PT_API_HOSTS, {}).get(SOPHOS_PT_GLOBAL_URL, None)
-        else:
-            self._base_url = None
-        self._partner_token = self._state.get(SOPHOS_PT_JSON, {}).get(SOPHOS_PT_TOKEN)
+            self._base_url = self._select_api_host(pt_json)
+            if self._base_url:
+                self._id_type = pt_json["idType"]
+                self._partner_token = pt_json.get(SOPHOS_PT_TOKEN)
+            else:
+                self._state.pop(SOPHOS_PT_JSON, None)
         return phantom.APP_SUCCESS
 
     def finalize(self):
+        if self._JWT_token and not self._store_encrypted_jwt(self._state.get(SOPHOS_JWT_JSON, {})):
+            self._state.pop(SOPHOS_JWT_JSON, None)
+            self._state.pop(SOPHOS_JWT_TOKEN_IS_ENCRYPTED, None)
         self.save_state(self._state)
         return phantom.APP_SUCCESS
+
+    def _load_jwt_from_state(self):
+        jwt_json = self._state.get(SOPHOS_JWT_JSON, {})
+        token = jwt_json.get(SOPHOS_JWT_TOKEN)
+        if not token:
+            return
+
+        if self._state.get(SOPHOS_JWT_TOKEN_IS_ENCRYPTED, False):
+            try:
+                self._JWT_token = encryption_helper.decrypt(token, self.get_asset_id())
+            except Exception as exc:
+                self.debug_print(f"Unable to decrypt cached JWT; discarding it: {self._get_error_message_from_exception(exc)}")
+                self._state.pop(SOPHOS_JWT_JSON, None)
+                self._state.pop(SOPHOS_JWT_TOKEN_IS_ENCRYPTED, None)
+            return
+
+        # Migrate legacy plaintext state immediately so the next state save is encrypted.
+        self._JWT_token = token
+        if not self._store_encrypted_jwt(jwt_json):
+            self._JWT_token = None
+            self._state.pop(SOPHOS_JWT_JSON, None)
+
+    def _store_encrypted_jwt(self, jwt_json):
+        try:
+            encrypted_token = encryption_helper.encrypt(self._JWT_token, self.get_asset_id())
+        except Exception as exc:
+            self.debug_print(f"Unable to encrypt cached JWT: {self._get_error_message_from_exception(exc)}")
+            return False
+        if not encrypted_token:
+            return False
+        encrypted_jwt = dict(jwt_json) if isinstance(jwt_json, dict) else {}
+        encrypted_jwt[SOPHOS_JWT_TOKEN] = encrypted_token
+        self._state[SOPHOS_JWT_JSON] = encrypted_jwt
+        self._state[SOPHOS_JWT_TOKEN_IS_ENCRYPTED] = True
+        return True
+
+    @staticmethod
+    def _validate_api_host(api_host):
+        if not isinstance(api_host, str):
+            return None
+        try:
+            parsed = urlparse(api_host)
+            hostname = parsed.hostname or ""
+            if parsed.port is not None:
+                return None
+        except (TypeError, ValueError):
+            return None
+
+        if (
+            parsed.scheme != "https"
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in ("", "/")
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+            or not re.fullmatch(r"api(?:-[a-z0-9]+)?\.central\.sophos\.com", hostname, re.IGNORECASE)
+        ):
+            return None
+        return f"https://{hostname.lower()}"
+
+    @staticmethod
+    def _quote_path_identifier(value):
+        return quote(str(value), safe="")
+
+    def _select_api_host(self, identity):
+        if not isinstance(identity, dict):
+            return None
+        id_type = identity.get("idType")
+        api_hosts = identity.get(SOPHOS_PT_API_HOSTS, {})
+        if not isinstance(api_hosts, dict):
+            return None
+        if id_type == "tenant":
+            candidate = api_hosts.get(SOPHOS_PT_DATA_REGION_URL)
+        elif id_type in ("organization", "partner"):
+            candidate = api_hosts.get(SOPHOS_PT_GLOBAL_URL)
+        else:
+            return None
+        return self._validate_api_host(candidate)
 
     def _validate_input(self, commaseparated_str, valid_values):
         """Validating input values provided as comma separated strings"""
@@ -109,7 +190,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Unable to parse JSON response. Error: {e!s}"), None)
 
         # Please specify the status codes here
-        if 200 <= r.status_code < 399:
+        if 200 <= r.status_code < 300:
             return RetVal(phantom.APP_SUCCESS, resp_json)
 
         # You should process the error returned in the json
@@ -117,9 +198,9 @@ class SophosEndpointProtectionConnector(BaseConnector):
 
         return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
 
-    def _process_response(self, r, action_result):
+    def _process_response(self, r, action_result, sensitive=False):
         # store the r_text in debug data, it will get dumped in the logs if the action fails
-        if hasattr(action_result, "add_debug_data"):
+        if not sensitive and hasattr(action_result, "add_debug_data"):
             action_result.add_debug_data({"r_status_code": r.status_code})
             action_result.add_debug_data({"r_text": r.text})
             action_result.add_debug_data({"r_headers": r.headers})
@@ -146,24 +227,23 @@ class SophosEndpointProtectionConnector(BaseConnector):
 
         return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
 
-    def _make_rest_call(self, endpoint, action_result, headers=None, params=None, data=None, json=None, method="get"):
+    def _make_rest_call(self, endpoint, action_result, headers=None, params=None, data=None, json=None, method="get", sensitive=False):
         resp_json = None
         try:
             request_func = getattr(requests, method)
         except AttributeError:
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Invalid method: {method}"), resp_json)
         try:
-            r = request_func(endpoint, json=json, data=data, headers=headers, params=params)
+            r = request_func(endpoint, json=json, data=data, headers=headers, params=params, allow_redirects=False)
             # self.save_progress("Request function results: {}".format(r.text))
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, (f"Error connecting to server. Details: {e!s}")), resp_json)
         # self.save_progress("Returning the results found for the request")
-        return self._process_response(r, action_result)
+        return self._process_response(r, action_result, sensitive=sensitive)
 
     def _make_rest_call_helper(self, action_result, endpoint, headers=None, params=None, data=None, json=None, method="get"):
-        jwt_json = self._state.get(SOPHOS_JWT_JSON, {})
         self.save_progress(f"idType: {self._id_type}")
-        if not jwt_json.get(SOPHOS_JWT_TOKEN) or not self._base_url or not self._id_type:
+        if not self._JWT_token or not self._base_url or not self._id_type:
             self.save_progress("Didn't find the JWT token, trying to fetch one.")
             ret_val = self._get_token(action_result)
             if phantom.is_fail(ret_val):
@@ -184,10 +264,10 @@ class SophosEndpointProtectionConnector(BaseConnector):
         self.save_progress("Trying to fetch data from the endpoint")
         ret_val, resp_json = self._make_rest_call(url, action_result, headers, params, data, json, method)
         self.save_progress(f"Response in JSON: {resp_json!s}")
-        msg = action_result.get_message()
+        msg = action_result.get_message() or ""
 
         if (
-            (msg and "token is invalid" in msg)
+            "token is invalid" in msg
             or "token has expired" in msg
             or "ExpiredAuthenticationToken" in msg
             or "authorization failed" in msg
@@ -228,16 +308,18 @@ class SophosEndpointProtectionConnector(BaseConnector):
         url = f"{JWT_TOKEN_ENDPOINT}"
         self.save_progress("Fetching the JWT token")
         self.save_progress(f"Hitting the URL for JWT token: {url}")
-        ret_val, resp_json = self._make_rest_call(url, action_result, headers=headers, data=data, method="post")
-        self.save_progress(f"Response in JSON: {resp_json}")
+        ret_val, resp_json = self._make_rest_call(url, action_result, headers=headers, data=data, method="post", sensitive=True)
         self.save_progress(f"Return value: {ret_val}")
         if not ret_val:
             return self.set_status(phantom.APP_ERROR, "Token not found")
 
         self.save_progress("Saving to state")
-        self._state[SOPHOS_JWT_JSON] = resp_json
+        if not isinstance(resp_json, dict) or not isinstance(resp_json.get(SOPHOS_JWT_TOKEN), str):
+            return action_result.set_status(phantom.APP_ERROR, "Sophos did not return a valid authentication token")
         self._JWT_token = resp_json[SOPHOS_JWT_TOKEN]
-        self.save_progress(f"Got the token: {self._JWT_token}")
+        if not self._store_encrypted_jwt(resp_json):
+            self._JWT_token = None
+            return action_result.set_status(phantom.APP_ERROR, "Unable to securely cache the authentication token")
 
         # Getting the X-Tenant-ID
         data = {}
@@ -249,14 +331,19 @@ class SophosEndpointProtectionConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
+        self._base_url = self._select_api_host(resp_json)
+        partner_token = resp_json.get(SOPHOS_PT_TOKEN) if isinstance(resp_json, dict) else None
+        id_type = resp_json.get("idType") if isinstance(resp_json, dict) else None
+        if not self._base_url or not isinstance(partner_token, str) or not partner_token.strip():
+            self._state.pop(SOPHOS_PT_JSON, None)
+            self._base_url = None
+            self._partner_token = None
+            self._id_type = None
+            return action_result.set_status(phantom.APP_ERROR, "Sophos returned an invalid identity or API host")
+
         self._state[SOPHOS_PT_JSON] = resp_json
-        self._partner_token = resp_json[SOPHOS_PT_TOKEN]
-        self._id_type = resp_json["idType"]
-        # idType = partner | organization | tenant
-        if resp_json["idType"] == "tenant":
-            self._base_url = resp_json[SOPHOS_PT_API_HOSTS][SOPHOS_PT_DATA_REGION_URL]
-        else:
-            self._base_url = resp_json[SOPHOS_PT_API_HOSTS][SOPHOS_PT_GLOBAL_URL]
+        self._partner_token = partner_token
+        self._id_type = id_type
         self.save_state(self._state)
         self.save_progress("Got the partner token")
         return phantom.APP_SUCCESS
@@ -277,7 +364,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
         params = {}
         data = {}
         endpoint = ENDPOINTS_ENDPOINT
-        ret_val, response = self._make_rest_call_helper(action_result, endpoint, params=params, data=json.dumps(data), method="get")
+        ret_val, _response = self._make_rest_call_helper(action_result, endpoint, params=params, data=json.dumps(data), method="get")
         if phantom.is_fail(ret_val):
             return self.set_status_save_progress(phantom.APP_ERROR, "Test Connectivity Failed")
         self.save_progress("Test Connectivity Passed")
@@ -320,7 +407,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
             return phantom.APP_SUCCESS
 
         elif action_name == "get individual endpoint":
-            final_endpoint = "{}/{}".format(endpoint, params.pop("endpointid"))
+            final_endpoint = "{}/{}".format(endpoint, self._quote_path_identifier(params.pop("endpointid")))
             ret_val, response = self._make_rest_call_helper(action_result, final_endpoint, params=params, data=json.dumps(data), method="get")
 
             if phantom.is_fail(ret_val):
@@ -333,7 +420,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
             return phantom.APP_SUCCESS
 
         elif action_name == "delete endpoint":
-            final_endpoint = "{}/{}".format(endpoint, params.pop("endpointid"))
+            final_endpoint = "{}/{}".format(endpoint, self._quote_path_identifier(params.pop("endpointid")))
             ret_val, response = self._make_rest_call_helper(action_result, final_endpoint, params=params, data=json.dumps(data), method="delete")
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
@@ -403,7 +490,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
         data = {}
-        endpoint = UPDATE_CHECK_ENDPOINT.format(param["endpointid"])
+        endpoint = UPDATE_CHECK_ENDPOINT.format(self._quote_path_identifier(param["endpointid"]))
         ret_val, response = self._make_rest_call_helper(action_result, endpoint, params={}, data=json.dumps(data), method="post")
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -417,7 +504,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
     def _handle_tamperprotection_settings(self, action_result, param):
         data = {}
         action_name = param.get("action_name")
-        endpoint = TAMPER_PROTECTION_ENDPOINT.format(param["endpointid"])
+        endpoint = TAMPER_PROTECTION_ENDPOINT.format(self._quote_path_identifier(param["endpointid"]))
 
         if action_name == "get settings":
             self.save_progress("Getting tamper protection settings")
@@ -467,7 +554,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         data = {}
-        endpoint = SCAN_ENDPOINT.format(param["endpointid"])
+        endpoint = SCAN_ENDPOINT.format(self._quote_path_identifier(param["endpointid"]))
         ret_val, response = self._make_rest_call_helper(action_result, endpoint, params={}, data=json.dumps(data), method="post")
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -547,7 +634,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
         if item_type not in SOPHOS_PARAMS_ITEMSTYPE:
             return action_result.set_status(phantom.APP_ERROR, SOPHOS_PARAMS_INVALID_ERR.format(name="item_type"))
 
-        param["action_endpoint"] = DELETE_ITEM.format(type=item_type, id=param["item_id"])
+        param["action_endpoint"] = DELETE_ITEM.format(type=item_type, id=self._quote_path_identifier(param["item_id"]))
 
         ret_val = self._handle_delete_settings(action_result, param)
         if phantom.is_fail(ret_val):
@@ -613,7 +700,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        param["action_endpoint"] = DELETE_SITE.format(id=param["site_id"])
+        param["action_endpoint"] = DELETE_SITE.format(id=self._quote_path_identifier(param["site_id"]))
         ret_val = self._handle_delete_settings(action_result, param)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -642,7 +729,7 @@ class SophosEndpointProtectionConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        endpoint = ISOLATION_INDIVIDUAL_ENDPOINT.format(param["endpoint_id"])
+        endpoint = ISOLATION_INDIVIDUAL_ENDPOINT.format(self._quote_path_identifier(param["endpoint_id"]))
         ret_val, response = self._make_rest_call_helper(action_result, endpoint, params={}, method="get")
         if phantom.is_fail(ret_val):
             return action_result.get_status()

--- a/sophosendpointprotection_consts.py
+++ b/sophosendpointprotection_consts.py
@@ -1,6 +1,6 @@
 # File: sophosendpointprotection_consts.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ SOPHOS_CLIENT_SECRET = "client_secret"  # pragma: allowlist secret
 
 SOPHOS_JWT_JSON = "jwt_json"
 SOPHOS_JWT_TOKEN = "access_token"
+SOPHOS_JWT_TOKEN_IS_ENCRYPTED = "jwt_token_is_encrypted"
 
 SOPHOS_PT_JSON = "pt_json"
 SOPHOS_PT_API_HOSTS = "apiHosts"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+class _ActionResult:
+    def __init__(self, parameters=None):
+        self.parameters = parameters or {}
+        self.status = True
+
+    def set_status(self, status, _message=None):
+        self.status = status
+        return status
+
+
+class _BaseConnector:
+    def __init__(self):
+        self._asset_id = "asset-id"
+
+    def get_asset_id(self):
+        return self._asset_id
+
+    def debug_print(self, *_args):
+        pass
+
+    def save_progress(self, *_args):
+        pass
+
+    def _get_error_message_from_exception(self, exc):
+        return str(exc)
+
+
+phantom = types.ModuleType("phantom")
+phantom_app = types.ModuleType("phantom.app")
+phantom_app.APP_SUCCESS = True
+phantom_app.APP_ERROR = False
+phantom_app.is_fail = lambda value: value is False
+phantom_action_result = types.ModuleType("phantom.action_result")
+phantom_action_result.ActionResult = _ActionResult
+phantom_base_connector = types.ModuleType("phantom.base_connector")
+phantom_base_connector.BaseConnector = _BaseConnector
+encryption_helper = types.ModuleType("encryption_helper")
+encryption_helper.encrypt = lambda value, salt: f"encrypted:{salt}:{value}"
+encryption_helper.decrypt = lambda value, salt: value.removeprefix(f"encrypted:{salt}:")
+requests = types.ModuleType("requests")
+requests.get = lambda *_args, **_kwargs: None
+bs4 = types.ModuleType("bs4")
+bs4.BeautifulSoup = object
+
+sys.modules.setdefault("phantom", phantom)
+sys.modules.setdefault("phantom.app", phantom_app)
+sys.modules.setdefault("phantom.action_result", phantom_action_result)
+sys.modules.setdefault("phantom.base_connector", phantom_base_connector)
+sys.modules.setdefault("encryption_helper", encryption_helper)
+sys.modules.setdefault("requests", requests)
+sys.modules.setdefault("bs4", bs4)
+
+from sophosendpointprotection_connector import SophosEndpointProtectionConnector
+from sophosendpointprotection_consts import (
+    SOPHOS_JWT_JSON,
+    SOPHOS_JWT_TOKEN,
+    SOPHOS_JWT_TOKEN_IS_ENCRYPTED,
+)
+
+
+class SecurityTests(unittest.TestCase):
+    def test_accepts_only_documented_sophos_api_origins(self):
+        valid = (
+            "https://api.central.sophos.com",
+            "https://api-us03.central.sophos.com",
+            "https://API-EU01.CENTRAL.SOPHOS.COM/",
+        )
+        invalid = (
+            None,
+            "http://api.central.sophos.com",
+            "https://api.central.sophos.com.evil.example",
+            "https://api.central.sophos.com:443",
+            "https://user@api.central.sophos.com",
+            "https://api.central.sophos.com/path",
+            "https://api.central.sophos.com?next=https://evil.example",
+            "https://central.sophos.com",
+        )
+
+        for value in valid:
+            self.assertIsNotNone(SophosEndpointProtectionConnector._validate_api_host(value))
+        for value in invalid:
+            self.assertIsNone(SophosEndpointProtectionConnector._validate_api_host(value))
+
+    def test_rejects_invalid_whoami_shapes(self):
+        connector = SophosEndpointProtectionConnector()
+        self.assertIsNone(connector._select_api_host(None))
+        self.assertIsNone(connector._select_api_host({"idType": "tenant", "apiHosts": "invalid"}))
+        self.assertIsNone(connector._select_api_host({"idType": "unexpected", "apiHosts": {"global": "https://api.central.sophos.com"}}))
+
+    def test_path_identifiers_are_encoded_as_single_segments(self):
+        self.assertEqual(SophosEndpointProtectionConnector._quote_path_identifier("../sites/1"), "..%2Fsites%2F1")
+        self.assertEqual(SophosEndpointProtectionConnector._quote_path_identifier("a?b#c"), "a%3Fb%23c")
+
+    def test_legacy_plaintext_jwt_is_migrated_to_encrypted_state(self):
+        connector = SophosEndpointProtectionConnector()
+        connector._state = {SOPHOS_JWT_JSON: {SOPHOS_JWT_TOKEN: "plaintext-token", "expires_in": 3600}}
+
+        connector._load_jwt_from_state()
+
+        self.assertEqual(connector._JWT_token, "plaintext-token")
+        self.assertEqual(connector._state[SOPHOS_JWT_JSON][SOPHOS_JWT_TOKEN], "encrypted:asset-id:plaintext-token")
+        self.assertTrue(connector._state[SOPHOS_JWT_TOKEN_IS_ENCRYPTED])
+
+    def test_undecryptable_jwt_is_discarded(self):
+        connector = SophosEndpointProtectionConnector()
+        connector._state = {
+            SOPHOS_JWT_JSON: {SOPHOS_JWT_TOKEN: "corrupt"},
+            SOPHOS_JWT_TOKEN_IS_ENCRYPTED: True,
+        }
+
+        with mock.patch("sophosendpointprotection_connector.encryption_helper.decrypt", side_effect=ValueError("bad ciphertext")):
+            connector._load_jwt_from_state()
+
+        self.assertIsNone(connector._JWT_token)
+        self.assertNotIn(SOPHOS_JWT_JSON, connector._state)
+        self.assertNotIn(SOPHOS_JWT_TOKEN_IS_ENCRYPTED, connector._state)
+
+    def test_rest_calls_do_not_follow_redirects(self):
+        connector = SophosEndpointProtectionConnector()
+        action_result = _ActionResult()
+        response = object()
+
+        with (
+            mock.patch("sophosendpointprotection_connector.requests.get", return_value=response) as request,
+            mock.patch.object(connector, "_process_response", return_value=(True, {})),
+        ):
+            connector._make_rest_call("https://api.central.sophos.com/test", action_result)
+
+        request.assert_called_once_with(
+            "https://api.central.sophos.com/test",
+            json=None,
+            data=None,
+            headers=None,
+            params=None,
+            allow_redirects=False,
+        )
+
+    def test_sensitive_responses_are_not_added_to_debug_data(self):
+        connector = SophosEndpointProtectionConnector()
+        action_result = mock.Mock()
+        response = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
+        response.json.return_value = {"access_token": "secret"}
+
+        connector._process_response(response, action_result, sensitive=True)
+
+        action_result.add_debug_data.assert_not_called()
+
+    def test_whoami_requires_nonempty_identity(self):
+        connector = SophosEndpointProtectionConnector()
+        connector._JWT_token = "token"
+        connector._state = {}
+        action_result = _ActionResult()
+        token_response = {"access_token": "token"}
+        invalid_whoami = {
+            "idType": "tenant",
+            "apiHosts": {"dataRegion": "https://api-us03.central.sophos.com"},
+        }
+
+        with (
+            mock.patch.object(connector, "_make_rest_call", side_effect=[(True, token_response), (True, invalid_whoami)]),
+            mock.patch.object(connector, "_store_encrypted_jwt", return_value=True),
+        ):
+            status = connector._get_token(action_result)
+
+        self.assertFalse(status)
+        self.assertIsNone(connector._base_url)
+        self.assertNotIn("pt_json", connector._state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate WHOAMI-provided API origins before sending bearer and tenant credentials
- disable HTTP redirects and keep OAuth token responses out of progress/debug logs
- encrypt cached JWT state, migrate legacy plaintext state, and discard undecryptable cache entries
- encode endpoint, item, and site identifiers as single URL path segments
- classify `delete site` as destructive and raise the explicitly approved minimum SOAR version to 6.3.0

## Validation

- `python3 -m unittest discover -s tests -v` (8 focused tests)
- `python3 -m py_compile sophosendpointprotection_connector.py sophosendpointprotection_consts.py tests/test_security.py`
- clean `pre-commit run --all-files` with dev-cicd-tools v2.2.4, including package dependencies, Semgrep, SOAR linting, and static tests
- verified signed commits and clean worktree

## References

- [Sophos API host documentation](https://developer.sophos.com/intro)
- [Sophos WHOAMI API](https://developer.sophos.com/docs/whoami-v1/1/routes/get)

## Tracking

- PAPP: PAPP-38049
- PSAAS: PSAAS-30835, PSAAS-31229, PSAAS-31371, PSAAS-31392
- Provenance: VULN-93560 / FS-1648; VULN-93954 / FS-2091; VULN-94096 / FS-2250; VULN-94117 / FS-2271

Written by Codex.
