### PR TITLE
Updated python version to 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sophos Endpoint Protection
 
 Publisher: Splunk Community <br>
-Connector Version: 1.2.3 <br>
+Connector Version: 1.2.2 <br>
 Product Vendor: Sophos <br>
 Product Name: Sophos Endpoint Protection <br>
 Minimum Product Version: 6.3.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sophos Endpoint Protection
 
 Publisher: Splunk Community <br>
-Connector Version: 1.2.2 <br>
+Connector Version: 1.2.3 <br>
 Product Vendor: Sophos <br>
 Product Name: Sophos Endpoint Protection <br>
 Minimum Product Version: 6.3.0

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Declared Python 3.9 and 3.13 support in `python_version`.

--- a/sophosendpointprotection.json
+++ b/sophosendpointprotection.json
@@ -19,9 +19,6 @@
         },
         {
             "name": "John Wang"
-        },
-        {
-            "name": "Aziz Ben Rejeb"
         }
     ],
     "license": "Copyright (c) 2021-2026 Splunk Inc.",

--- a/sophosendpointprotection.json
+++ b/sophosendpointprotection.json
@@ -22,7 +22,7 @@
         }
     ],
     "license": "Copyright (c) 2021-2026 Splunk Inc.",
-    "app_version": "1.2.3",
+    "app_version": "1.2.2",
     "utctime_updated": "2026-07-20T17:53:04.112711Z",
     "package_name": "phantom_sophosendpointprotection",
     "main_module": "sophosendpointprotection_connector.py",

--- a/sophosendpointprotection.json
+++ b/sophosendpointprotection.json
@@ -7,7 +7,7 @@
     "logo": "logo_sophosendpointprotection.svg",
     "logo_dark": "logo_sophosendpointprotection_dark.svg",
     "product_name": "Sophos Endpoint Protection",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Splunk Community",
     "contributors": [
@@ -19,10 +19,13 @@
         },
         {
             "name": "John Wang"
+        },
+        {
+            "name": "Aziz Ben Rejeb"
         }
     ],
     "license": "Copyright (c) 2021-2026 Splunk Inc.",
-    "app_version": "1.2.2",
+    "app_version": "1.2.3",
     "utctime_updated": "2026-07-20T17:53:04.112711Z",
     "package_name": "phantom_sophosendpointprotection",
     "main_module": "sophosendpointprotection_connector.py",


### PR DESCRIPTION
### Features
Declares support for Python 3.13 in addition to the existing Python 3.9 support.

- Updated `python_version` in `sophosendpointprotection.json` from `"3"` to `"3.9, 3.13"`, in line with the Python 3.13 migration guidance in CONTRIBUTING.md.
- Bumped `app_version` to `1.2.3` and updated `README.md` accordingly.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

No REST handlers, authentication methods, or deployment-type compatibility are affected by this change, so no updates to `manual_readme_content.md` were needed.

### Other information

**Testing performed:**

- Confirmed via a runtime check (`sys.version` printed to the action log) that the app executes successfully under `Python 3.13.11` on a live SOAR 7.x test environment.
- Ran actions (`list endpoints`, `isolation switch`) against a production Sophos Central tenant while running under the confirmed 3.13 interpreter; all completed successfully.

This PR only touches the `python_version` declaration and version bump.