### PR TITLE
Fixed Handle Test Connectivity Function

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Fixed an intermittent connection reset (`ConnectionResetError(104)`) in `test connectivity`, caused by sending a GET request with a JSON body. The request now sends a plain GET with no body, consistent with the connector's other read actions.

--- a/sophosendpointprotection_connector.py
+++ b/sophosendpointprotection_connector.py
@@ -362,9 +362,8 @@ class SophosEndpointProtectionConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
         self.save_progress("Connecting to the endpoint for test connectivity")
         params = {}
-        data = {}
         endpoint = ENDPOINTS_ENDPOINT
-        ret_val, _response = self._make_rest_call_helper(action_result, endpoint, params=params, data=json.dumps(data), method="get")
+        ret_val, _response = self._make_rest_call_helper(action_result, endpoint, params=params, data=None, method="get")
         if phantom.is_fail(ret_val):
             return self.set_status_save_progress(phantom.APP_ERROR, "Test Connectivity Failed")
         self.save_progress("Test Connectivity Passed")


### PR DESCRIPTION
### Bug Fixes

Fixes an intermittent connection reset error in `test connectivity`.

- `_handle_test_connectivity` previously sent a GET request carrying a JSON
  body (`data=json.dumps({})`). This occasionally triggered
  `ConnectionResetError(104, 'Connection reset by peer')` after a successful
  OAuth token exchange, since `api-us03.central.sophos.com` sits behind an
  Akamai edge network, which can handle GET-with-body requests inconsistently.
- Changed the request to a plain GET with no body (`data=None`), matching the
  pattern already used by every other read action in this connector.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

### Other information

**Testing performed:**

- Reproduced the intermittent reset repeatedly on a live SOAR environment against
  a production Sophos Central tenant before the fix.
- After the fix, ran `test connectivity` multiple times in succession; all passed
  consistently with no resets.